### PR TITLE
Fix lint issue

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI - Backend
 
 on:
   push:

--- a/.github/workflows/ci-frontend-cli.yml
+++ b/.github/workflows/ci-frontend-cli.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI - Frontend CLI
 
 on:
   push:

--- a/.github/workflows/ci-test-end-to-end.yml
+++ b/.github/workflows/ci-test-end-to-end.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI - End-to-End Integration Tests
 
 on:
   push:

--- a/frontend-cli/test/unit/services/game.spec.ts
+++ b/frontend-cli/test/unit/services/game.spec.ts
@@ -593,7 +593,7 @@ describe('The game file service', () => {
           expect(existsStub.calledOnce).to.equal(true);
           expect(existsStub.firstCall.args.slice(0, -1)).to.deep.equal([
             '/home/test/.patience-cli'
-          ])
+          ]);
         });
 
         it('Does not delete the game data file', () => {
@@ -621,7 +621,7 @@ describe('The game file service', () => {
             expect(existsStub.calledOnce).to.equal(true);
             expect(existsStub.firstCall.args.slice(0, -1)).to.deep.equal([
               '/home/test/.patience-cli'
-            ])
+            ]);
           });
 
           it('Deletes the game data file', () => {


### PR DESCRIPTION
+ For some reason the linter didn't run so missing semicolons came in.
+ Change `name` attribute of CI configurations.