### PR TITLE
Improve logging configuration.

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "author": "Ben New <ben@leftclick.com.au>",
   "license": "MIT",
   "config": {
-    "service": "event-sourced-patience",
+    "service": "patience",
     "default_stage": "dev"
   },
   "scripts": {

--- a/test-end-to-end/package.json
+++ b/test-end-to-end/package.json
@@ -8,7 +8,7 @@
     "ts-node": "ts-node",
     "lint": "tslint --project tsconfig.json",
     "test": "mocha -t 180000 -r ts-node/register test/**/*.spec.ts",
-    "cleanup": "ts-node src/cloudwatch"
+    "cleanup": "ts-node src/cloudwatch cleanup"
   },
   "devDependencies": {
     "@types/aws-sdk": "^2.7.0",

--- a/test-end-to-end/src/cloudformation.ts
+++ b/test-end-to-end/src/cloudformation.ts
@@ -1,9 +1,10 @@
 import { CloudFormation } from 'aws-sdk';
 import { StageName } from './types';
 
-// NOTE This is coupled to string logic in `package.json` scripts, equivalent changes must be made in both places.
+// NOTE This prefix is coupled to string logic in `package.json` scripts and in `cloudwatch.ts` in this directory.
+// Changes must be replicated in all three places.
 const getStackName = (stage: StageName) => {
-  return `event-sourced-patience-${stage}`;
+  return `patience-${stage}`;
 };
 
 export const getStackOutputs = async <T extends string>(

--- a/test-end-to-end/src/cloudwatch.ts
+++ b/test-end-to-end/src/cloudwatch.ts
@@ -3,15 +3,18 @@ import { CloudWatchLogs } from 'aws-sdk';
 export const cleanUpLogGroups = async () => {
   const logs = new CloudWatchLogs();
 
+  // NOTE This prefix is coupled to string logic in `package.json` scripts and in `cloudformation.ts` in this directory.
+  // Changes must be replicated in all three places.
   const { logGroups, nextToken } = await logs
-    .describeLogGroups({ logGroupNamePrefix: '/aws/lambda/event-sourced-patience-end2end' })
+    .describeLogGroups({ logGroupNamePrefix: '/aws/lambda/patience-end2end' })
     .promise();
 
-  if (!logGroups) {
+  if (!logGroups || logGroups.length < 1) {
+    console.info('No log groups to delete');
     return;
   }
 
-  console.info(`Deleting the following log groups: ${JSON.stringify(logGroups)}`);
+  console.info(`Deleting the following log groups: ${JSON.stringify(logGroups, null, 2)}`);
 
   await logGroups.reduce(
     async (promise, { logGroupName }) => {
@@ -28,7 +31,18 @@ export const cleanUpLogGroups = async () => {
 };
 
 if (require.main === module) {
-  cleanUpLogGroups()
-    .then(() => console.log('Log group cleanup completed'))
-    .catch((error) => console.error('Failed to clean up log groups', error));
+  if (process.argv.length <= 2) {
+    console.error(`Missing argument: ${process.argv[0]} ${process.argv[1]} [command]`);
+    process.exit(1);
+  }
+  switch (process.argv[2]) {
+    case 'cleanup':
+      cleanUpLogGroups()
+        .then(() => console.log('Log group cleanup completed'))
+        .catch((error) => console.error('Failed to clean up log groups', error));
+      break;
+    default:
+      console.error(`Unknown command ${process.argv[2]}`);
+      process.exit(2);
+  }
 }


### PR DESCRIPTION
+ Use `patience` as the base stack name, not `event-sourced-patience`
+ This gives more space for the log groups so that they are actually unique per run of the tests
+ Require a `cleanup` command to call `cleanUpLogGroups` and specify it in `package.json` script
+ Improve logging in `cleanUpLogGroups`