### PR TITLE
More code tweaks

### DIFF
--- a/backend/src/handlers/http/game/delete.ts
+++ b/backend/src/handlers/http/game/delete.ts
@@ -5,7 +5,7 @@ import { APIGatewayProxyHandlerWithData, checkArguments, checkEnvironment, wrapH
 export const deleteGameHandler: APIGatewayProxyHandlerWithData = async ({ pathParameters }) => {
   checkEnvironment(['DB_TABLE_EVENTS']);
 
-  const { gameId } = pathParameters || {};
+  const { gameId } = pathParameters;
 
   checkArguments({ gameId });
 

--- a/backend/src/handlers/http/game/get.ts
+++ b/backend/src/handlers/http/game/get.ts
@@ -12,7 +12,7 @@ import {
 export const getGameHandler: APIGatewayProxyHandlerWithData = async ({ pathParameters }) => {
   checkEnvironment(['DB_TABLE_EVENTS']);
 
-  const { gameId } = pathParameters || {};
+  const { gameId } = pathParameters;
 
   checkArguments({ gameId });
 

--- a/backend/src/handlers/http/game/patch.ts
+++ b/backend/src/handlers/http/game/patch.ts
@@ -24,7 +24,7 @@ const getDelegation = (key: GameplayCommandName) => ({
 export const patchGameHandler: APIGatewayProxyHandlerWithData = async ({ data, pathParameters }) => {
   checkEnvironment(['DB_TABLE_EVENTS']);
 
-  const { gameId, moveType } = pathParameters || {};
+  const { gameId, moveType } = pathParameters;
 
   checkArguments({ gameId, moveType });
 

--- a/backend/src/handlers/http/helpers.ts
+++ b/backend/src/handlers/http/helpers.ts
@@ -4,6 +4,7 @@ import { BadRequest, InternalServerError, NotFound } from 'http-errors';
 
 export interface APIGatewayProxyEventWithData extends Partial<APIGatewayProxyEvent> {
   data?: object;
+  pathParameters: { [name: string]: string };
 }
 
 export interface APIGatewayProxyResultWithData extends Partial<APIGatewayProxyResult> {
@@ -15,11 +16,12 @@ export type APIGatewayProxyHandlerWithData =
 
 export const wrapHttpHandler =
   (handler: APIGatewayProxyHandlerWithData): APIGatewayProxyHandler =>
-    async (event, context) => {
+    async ({ pathParameters, body, ...event }, context) => {
       try {
         const wrappedEvent = {
           ...event,
-          data: event.body ? JSON.parse(event.body) : undefined
+          pathParameters: pathParameters || {},
+          data: body ? JSON.parse(body) : undefined
         };
 
         const { data, ...result } = await handler(wrappedEvent, context, () => undefined) || {};

--- a/backend/test/unit/handlers/http/helpers.spec.ts
+++ b/backend/test/unit/handlers/http/helpers.spec.ts
@@ -31,7 +31,7 @@ describe('Helper functions', () => {
         outerHandler = wrapHttpHandler(innerHandler);
       });
 
-      describe('When the resulting function is invoked', () => {
+      describe('When the resulting function is invoked with a body', () => {
         let event: APIGatewayProxyEvent;
         let context: Context;
         let result: APIGatewayProxyResultWithData | void;
@@ -42,10 +42,59 @@ describe('Helper functions', () => {
           result = await outerHandler(event, context, undefined as any);
         });
 
-        it('Calls the inner handler with data', () => {
+        it('Calls the inner handler with data and an empty set of path parameters', () => {
           expect(innerHandler.callCount).to.equal(1);
           expect(innerHandler.firstCall.args[0]).to.deep.equal({
-            ...event,
+            pathParameters: {},
+            data: {
+              parameter: 'value'
+            }
+          });
+          expect(innerHandler.firstCall.args[1]).to.equal(context);
+        });
+
+        it('Does not log any errors', () => {
+          expect(consoleErrorStub.callCount).to.equal(0);
+        });
+
+        it('Returns the correct HTTP response', () => {
+          expect(result).to.deep.equal({
+            statusCode: 204,
+            body: ''
+          });
+        });
+      });
+
+      describe('When the resulting function is invoked with a body and other properties', () => {
+        let event: APIGatewayProxyEvent;
+        let context: Context;
+        let result: APIGatewayProxyResultWithData | void;
+
+        beforeEach(async () => {
+          event = {
+            body: '{"parameter":"value"}',
+            pathParameters: {
+              key: 'value'
+            },
+            httpMethod: 'patch',
+            headers: {
+              authorization: 'Bearer tokenGoesHere'
+            }
+          } as unknown as APIGatewayProxyEvent;
+          context = {} as Context;
+          result = await outerHandler(event, context, undefined as any);
+        });
+
+        it('Calls the inner handler with data and other properties except body', () => {
+          expect(innerHandler.callCount).to.equal(1);
+          expect(innerHandler.firstCall.args[0]).to.deep.equal({
+            pathParameters: {
+              key: 'value'
+            },
+            httpMethod: 'patch',
+            headers: {
+              authorization: 'Bearer tokenGoesHere'
+            },
             data: {
               parameter: 'value'
             }
@@ -88,10 +137,10 @@ describe('Helper functions', () => {
           result = await outerHandler(event, context, undefined as any);
         });
 
-        it('Calls the inner handler with data', () => {
+        it('Calls the inner handler with data and an empty set of path parameters', () => {
           expect(innerHandler.callCount).to.equal(1);
           expect(innerHandler.firstCall.args[0]).to.deep.equal({
-            ...event,
+            pathParameters: {},
             data: {
               parameter: 'value'
             }
@@ -135,10 +184,10 @@ describe('Helper functions', () => {
           result = await outerHandler(event, context, undefined as any);
         });
 
-        it('Calls the inner handler with data', () => {
+        it('Calls the inner handler with data and an empty set of path parameters', () => {
           expect(innerHandler.callCount).to.equal(1);
           expect(innerHandler.firstCall.args[0]).to.deep.equal({
-            ...event,
+            pathParameters: {},
             data: {
               parameter: 'value'
             }
@@ -182,10 +231,10 @@ describe('Helper functions', () => {
           result = await outerHandler(event, context, undefined as any);
         });
 
-        it('Calls the inner handler with data', () => {
+        it('Calls the inner handler with data and an empty set of path parameters', () => {
           expect(innerHandler.callCount).to.equal(1);
           expect(innerHandler.firstCall.args[0]).to.deep.equal({
-            ...event,
+            pathParameters: {},
             data: {
               parameter: 'value'
             }
@@ -221,13 +270,13 @@ describe('Helper functions', () => {
       });
 
       describe('When the resulting function is invoked', () => {
-        it('Throws the error from the inner handler with data', async () => {
+        it('Throws the error from the inner handler with data and empty set of path parameters', async () => {
           const event = { body: '{"parameter":"value"}' } as APIGatewayProxyEvent;
           const context = {} as Context;
           await expect(outerHandler(event, context, undefined as any)).to.be.eventually.rejectedWith(thrownError);
           expect(innerHandler.callCount).to.equal(1);
           expect(innerHandler.firstCall.args[0]).to.deep.equal({
-            ...event,
+            pathParameters: {},
             data: {
               parameter: 'value'
             }

--- a/test-end-to-end/test/configurations/gameReadyToClaimVictory.ts
+++ b/test-end-to-end/test/configurations/gameReadyToClaimVictory.ts
@@ -44,571 +44,700 @@ export const gameReadyToClaimVictory = (gameId: GameId, apiBaseUrl: string) => (
   expectedErrorTape: [],
   expectedEvents: [
     {
+      gameId,
       eventType: GameEventType.gameCreated,
       tableau: gameCreatedTableau,
       stock: gameCreatedStock
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       toIndex: 2,
       count: 1,
       fromIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       toIndex: 5,
       count: 1,
       fromIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       tableauIndex: 4,
       foundationIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       toIndex: 0,
       count: 1,
       fromIndex: 3,
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste,
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste,
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 3,
       fromIndex: 5,
       toIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 5,
       toIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 6,
       toIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 5,
       toIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 2,
       fromIndex: 3,
       toIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.wasteResetToStock
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToFoundation,
       foundationIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 4,
       fromIndex: 1,
       toIndex: 6,
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.wasteResetToStock
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 5,
       toIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToFoundation,
       foundationIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 9,
       fromIndex: 6,
       toIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 6,
       toIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wasteResetToStock
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wasteResetToStock
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 4,
       toIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 2,
       fromIndex: 3,
       toIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 3,
       toIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 2,
       fromIndex: 2,
       toIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 2,
       toIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.wasteResetToStock
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToFoundation,
       foundationIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 7,
       fromIndex: 5,
       toIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 5,
       fromIndex: 4,
       toIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 3
     },
     {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 0,
-      tableauIndex: 0
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 1,
-      tableauIndex: 1
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 2,
-      tableauIndex: 2
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 3,
-      tableauIndex: 3
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 3,
-      tableauIndex: 0
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 0,
-      tableauIndex: 1
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 1,
-      tableauIndex: 2
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 2,
-      tableauIndex: 3
-    },
-    {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 3,
+      foundationIndex: 1,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 1,
+      foundationIndex: 3,
       tableauIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 2,
+      foundationIndex: 0,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 0,
+      foundationIndex: 2,
       tableauIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 3
     },
     {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 3,
+      tableauIndex: 0
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 2,
+      tableauIndex: 1
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 1,
+      tableauIndex: 2
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 0,
+      tableauIndex: 3
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 0,
+      tableauIndex: 0
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 3,
+      tableauIndex: 1
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 2,
+      tableauIndex: 2
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 1,
+      tableauIndex: 3
+    },
+    {
+      gameId,
       eventType: GameEventType.victoryClaimed
     }
   ]

--- a/test-end-to-end/test/configurations/newGameForInvalidCommandsAndHelp.ts
+++ b/test-end-to-end/test/configurations/newGameForInvalidCommandsAndHelp.ts
@@ -95,6 +95,7 @@ export const newGameForInvalidCommandsAndHelp = (gameId: GameId, apiBaseUrl: str
   ],
   expectedEvents: [
     {
+      gameId,
       eventType: GameEventType.gameCreated,
       tableau: gameCreatedTableau,
       stock: gameCreatedStock

--- a/test-end-to-end/test/configurations/newGamePlayToVictory.ts
+++ b/test-end-to-end/test/configurations/newGamePlayToVictory.ts
@@ -3,7 +3,7 @@ import { createGameNoMovesMade, gameCreatedStock, gameCreatedTableau } from '../
 
 // tslint:disable:max-line-length
 
-// BASE CASE - FORFEIT: Load a game that has only been created, and forfeit it.
+// PLAY ENTIRE GAME: Play a whole game from start to finish and claim victory.
 export const newGamePlayToVictory = (gameId: GameId, apiBaseUrl: string) => ({
   initialEvents: createGameNoMovesMade(gameId),
   inputTape: [
@@ -3031,571 +3031,700 @@ export const newGamePlayToVictory = (gameId: GameId, apiBaseUrl: string) => ({
   expectedErrorTape: [],
   expectedEvents: [
     {
+      gameId,
       eventType: GameEventType.gameCreated,
       tableau: gameCreatedTableau,
       stock: gameCreatedStock
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 0,
       toIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 1,
       toIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 3,
       toIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 3,
       fromIndex: 5,
       toIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 5,
       toIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 6,
       toIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 5,
       toIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 2,
       fromIndex: 3,
       toIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.wasteResetToStock
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToFoundation,
       foundationIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 4,
       fromIndex: 1,
       toIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.wasteResetToStock
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 5,
       toIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToFoundation,
       foundationIndex: 1,
       },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 5,
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 9,
       fromIndex: 6,
       toIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 6,
       toIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 6
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.wasteResetToStock
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.wasteResetToStock
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 4,
       toIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste,
       },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 2,
       fromIndex: 3,
       toIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 3,
       toIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 2,
       fromIndex: 2,
       toIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste,
       },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 1,
       fromIndex: 2,
       toIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 5
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.wasteResetToStock
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToFoundation,
       foundationIndex: 1
       },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste
       },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.wastePlayedToTableau,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 7,
       fromIndex: 5,
       toIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       count: 5,
       fromIndex: 4,
       toIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 4
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 3
     },
     {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 0,
-      tableauIndex: 0
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 1,
-      tableauIndex: 1
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 2,
-      tableauIndex: 2
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 3,
-      tableauIndex: 3
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 3,
-      tableauIndex: 0
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 0,
-      tableauIndex: 1
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 1,
-      tableauIndex: 2
-    },
-    {
-      eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 2,
-      tableauIndex: 3
-    },
-    {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 3,
+      foundationIndex: 1,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 1,
+      foundationIndex: 3,
       tableauIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 2,
+      foundationIndex: 0,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
-      foundationIndex: 0,
+      foundationIndex: 2,
       tableauIndex: 3
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 0,
       tableauIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 3,
       tableauIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 2,
       tableauIndex: 2
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       foundationIndex: 1,
       tableauIndex: 3
     },
     {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 3,
+      tableauIndex: 0
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 2,
+      tableauIndex: 1
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 1,
+      tableauIndex: 2
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 0,
+      tableauIndex: 3
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 0,
+      tableauIndex: 0
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 3,
+      tableauIndex: 1
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 2,
+      tableauIndex: 2
+    },
+    {
+      gameId,
+      eventType: GameEventType.tableauPlayedToFoundation,
+      foundationIndex: 1,
+      tableauIndex: 3
+    },
+    {
+      gameId,
       eventType: GameEventType.victoryClaimed
     }
   ]

--- a/test-end-to-end/test/configurations/newGameToForfeit.ts
+++ b/test-end-to-end/test/configurations/newGameToForfeit.ts
@@ -56,11 +56,13 @@ export const newGameToForfeit = (gameId: GameId, apiBaseUrl: string) => ({
   expectedErrorTape: [],
   expectedEvents: [
     {
+      gameId,
       eventType: GameEventType.gameCreated,
       tableau: gameCreatedTableau,
       stock: gameCreatedStock
     },
     {
+      gameId,
       eventType: GameEventType.gameForfeited
     }
   ]

--- a/test-end-to-end/test/configurations/newGameToMakeSomeMoves.ts
+++ b/test-end-to-end/test/configurations/newGameToMakeSomeMoves.ts
@@ -170,37 +170,44 @@ export const newGameToMakeSomeMoves = (gameId: GameId, apiBaseUrl: string) => ({
   expectedErrorTape: [],
   expectedEvents: [
     {
+      gameId,
       eventType: GameEventType.gameCreated,
       tableau: gameCreatedTableau,
       stock: gameCreatedStock
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       toIndex: 2,
       count: 1,
       fromIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       toIndex: 5,
       count: 1,
       fromIndex: 1
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToFoundation,
       tableauIndex: 4,
       foundationIndex: 0
     },
     {
+      gameId,
       eventType: GameEventType.tableauPlayedToTableau,
       toIndex: 0,
       count: 1,
       fromIndex: 3,
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste,
     },
     {
+      gameId,
       eventType: GameEventType.stockDealtToWaste,
     }
   ]

--- a/test-end-to-end/test/index.spec.ts
+++ b/test-end-to-end/test/index.spec.ts
@@ -84,10 +84,10 @@ describe('End-to-end integration tests', () => {
               `Tape from error stream does not match for game "${gameId}`);
           });
 
-          it('Matches the events in the database', async () => {
+          it('Matches the events in the database (ignoring timestamps)', async () => {
             assert.deepEqual(
               actualEvents.map(({ eventTimestamp, ...event }) => event),
-              testConfiguration.expectedEvents.map((event) => ({ gameId, ...event })),
+              testConfiguration.expectedEvents,
               `Incorrect events found for game "${gameId}"`);
           });
         });


### PR DESCRIPTION
+ `wrapHttpHandler` now ensures `pathParameters` has a value (empty object by default) and remove repetitive code in handlers
+ `wrapHttpHandler` no longer passes the `body` request attribute to the passed-in handler
+ Put the `gameId` into the `expectedEvents` of each game configuration explicitly, rather than synthesising it in the test
+ Minor test output improvement