### PR TITLE
Remove CORS, we don't need it.

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -13,9 +13,6 @@ Globals:
     Runtime: nodejs12.x
     Tracing: Active
   Api:
-    Cors:
-      AllowOrigin: "'*'"
-      AllowHeaders: "'Accept,Content-Type'"
     TracingEnabled: true
     MethodSettings:
       - LoggingLevel: INFO


### PR DESCRIPTION
CORS was enabled, probably due to copying from some previous project at some point, and never removing it, but it's a distraction so it's gone now.