### PR TITLE
Rename vars for readability

### DIFF
--- a/backend/src/commands/processors/index.ts
+++ b/backend/src/commands/processors/index.ts
@@ -1,0 +1,18 @@
+import { GameplayCommandName } from '../types';
+import { dealStockToWaste } from './dealStockToWaste';
+import { resetWasteToStock } from './resetWasteToStock';
+import { playWasteToTableau } from './playWasteToTableau';
+import { playWasteToFoundation } from './playWasteToFoundation';
+import { playTableauToFoundation } from './playTableauToFoundation';
+import { playTableauToTableau } from './playTableauToTableau';
+import { claimVictory } from './claimVictory';
+
+export const getCommandProcessor = (key: GameplayCommandName) => ({
+  dealStockToWaste,
+  resetWasteToStock,
+  playWasteToTableau,
+  playWasteToFoundation,
+  playTableauToFoundation,
+  playTableauToTableau,
+  claimVictory
+}[key]);

--- a/backend/src/handlers/http/game/delete.ts
+++ b/backend/src/handlers/http/game/delete.ts
@@ -6,7 +6,6 @@ export const deleteGameHandler: APIGatewayProxyHandlerWithData = async ({ pathPa
   checkEnvironment(['DB_TABLE_EVENTS']);
 
   const { gameId } = pathParameters;
-
   checkArguments({ gameId });
 
   await forfeitGame({ gameId });

--- a/backend/src/handlers/http/game/get.ts
+++ b/backend/src/handlers/http/game/get.ts
@@ -13,11 +13,9 @@ export const getGameHandler: APIGatewayProxyHandlerWithData = async ({ pathParam
   checkEnvironment(['DB_TABLE_EVENTS']);
 
   const { gameId } = pathParameters;
-
   checkArguments({ gameId });
 
   const events = await loadEvents(gameId);
-
   checkResultArray(events, `Game ${gameId} not found`);
 
   const { score, status } = buildScoreState(events);

--- a/backend/src/handlers/http/game/patch.ts
+++ b/backend/src/handlers/http/game/patch.ts
@@ -2,38 +2,18 @@ import { loadEvents } from '../../../events/load';
 import { buildTableState } from '../../../state/table';
 import { buildScoreState } from '../../../state/score';
 import { GameplayCommandName } from '../../../commands/types';
-import { playWasteToTableau } from '../../../commands/processors/playWasteToTableau';
-import { playTableauToTableau } from '../../../commands/processors/playTableauToTableau';
-import { playTableauToFoundation } from '../../../commands/processors/playTableauToFoundation';
-import { playWasteToFoundation } from '../../../commands/processors/playWasteToFoundation';
-import { dealStockToWaste } from '../../../commands/processors/dealStockToWaste';
-import { resetWasteToStock } from '../../../commands/processors/resetWasteToStock';
-import { claimVictory } from '../../../commands/processors/claimVictory';
+import { getCommandProcessor } from '../../../commands/processors';
 import { APIGatewayProxyHandlerWithData, checkArguments, checkEnvironment, wrapHttpHandler } from '../helpers';
-
-const getDelegation = (key: GameplayCommandName) => ({
-  dealStockToWaste,
-  resetWasteToStock,
-  playWasteToTableau,
-  playWasteToFoundation,
-  playTableauToFoundation,
-  playTableauToTableau,
-  claimVictory
-}[key]);
 
 export const patchGameHandler: APIGatewayProxyHandlerWithData = async ({ data, pathParameters }) => {
   checkEnvironment(['DB_TABLE_EVENTS']);
 
   const { gameId, moveType } = pathParameters;
-
   checkArguments({ gameId, moveType });
 
-  const delegation = getDelegation(moveType as GameplayCommandName);
-
+  const commandProcessor = getCommandProcessor(moveType as GameplayCommandName);
   const events = await loadEvents(gameId);
-
-  const addedEvent = await delegation({ gameId, ...data as any });
-
+  const addedEvent = await commandProcessor({ gameId, ...data as any });
   const newEvents = [...events, addedEvent];
 
   const { score, status } = buildScoreState(newEvents);

--- a/backend/src/handlers/http/game/post.ts
+++ b/backend/src/handlers/http/game/post.ts
@@ -8,7 +8,6 @@ export const postGameHandler: APIGatewayProxyHandlerWithData = async () => {
   checkEnvironment(['DB_TABLE_EVENTS']);
 
   const createGameEvent = await createGame();
-
   const gameId = createGameEvent.gameId;
   const { score, status } = buildScoreState([createGameEvent]);
   const table = buildTableState([createGameEvent]);

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -13,9 +13,6 @@ Globals:
     Runtime: nodejs12.x
     Tracing: Active
   Api:
-    Cors:
-      AllowOrigin: "'*'"
-      AllowHeaders: "'Accept,Content-Type'"
     TracingEnabled: true
     MethodSettings:
       - LoggingLevel: INFO


### PR DESCRIPTION
+ Rename variables mentioning `delegations` to what it actually is, `commandProcessors`
+ Move what is now `getCommandProcessor` to its own module in the right place, simplifying the handler
+ Change some spacing
