### PR TITLE
Add a materialised "aggregates" read model

### DIFF
--- a/backend/src/events/scan.ts
+++ b/backend/src/events/scan.ts
@@ -1,0 +1,23 @@
+import { DynamoDB } from 'aws-sdk';
+import { GameEvent } from './types';
+
+export const scanEvents = async (filterField: string, filterValues: string[], startKey?: DynamoDB.DocumentClient.Key): Promise<GameEvent[]> => {
+  const { Items: items, LastEvaluatedKey: lastKey } = await new DynamoDB.DocumentClient()
+    .scan({
+      TableName: process.env.DB_TABLE_EVENTS as string,
+      ExclusiveStartKey: startKey,
+      FilterExpression: filterValues
+        .reduce<string[]>((parts, value, index) => [...parts, `#key${index} = :value${index}`], [])
+        .join(' or '),
+      ExpressionAttributeNames: filterValues
+        .reduce((names, value, index) => ({ ...names, [`#key${index}`]: filterField }), {}),
+      ExpressionAttributeValues: filterValues
+        .reduce((values, value, index) => ({ ...values, [`:value${index}`]: value }), {})
+    })
+    .promise();
+
+  return [
+    ...(items || []) as GameEvent[],
+    ...(lastKey ? await scanEvents(filterField, filterValues, lastKey) : [])
+  ];
+};

--- a/backend/src/events/scan.ts
+++ b/backend/src/events/scan.ts
@@ -1,7 +1,11 @@
 import { DynamoDB } from 'aws-sdk';
 import { GameEvent } from './types';
 
-export const scanEvents = async (filterField: string, filterValues: string[], startKey?: DynamoDB.DocumentClient.Key): Promise<GameEvent[]> => {
+export const scanEvents = async (
+  filterField: string,
+  filterValues: string[],
+  startKey?: DynamoDB.DocumentClient.Key
+): Promise<GameEvent[]> => {
   const { Items: items, LastEvaluatedKey: lastKey } = await new DynamoDB.DocumentClient()
     .scan({
       TableName: process.env.DB_TABLE_EVENTS as string,

--- a/backend/src/handlers/dynamodb/events/stream.ts
+++ b/backend/src/handlers/dynamodb/events/stream.ts
@@ -1,0 +1,18 @@
+import { DynamoDBStreamHandler } from 'aws-lambda';
+import { GameEvent } from '../../../events/types';
+import { loadAggregates, saveAggregates } from '../../../state/aggregates/persistence';
+import { buildAggregates } from '../../../state/aggregates';
+
+const stripTypes = (input: Record<string, any>) => Object.keys(input).reduce((result, key) => ({ ...result, [key]: input[key][Object.keys(input[key])[0]] }), {});
+
+export const handler: DynamoDBStreamHandler = async ({ Records: records }) => {
+  const aggregates = await loadAggregates() || {};
+
+  const events = records
+    .map(({ dynamodb }) => (dynamodb ? stripTypes(dynamodb.NewImage as Record<string, any>) : undefined))
+    .filter((x) => !!x) as GameEvent[];
+
+  const newAggregates = await buildAggregates(events, aggregates);
+
+  await saveAggregates(newAggregates);
+};

--- a/backend/src/handlers/dynamodb/events/stream.ts
+++ b/backend/src/handlers/dynamodb/events/stream.ts
@@ -3,7 +3,8 @@ import { GameEvent } from '../../../events/types';
 import { loadAggregates, saveAggregates } from '../../../state/aggregates/persistence';
 import { buildAggregates } from '../../../state/aggregates';
 
-const stripTypes = (input: Record<string, any>) => Object.keys(input).reduce((result, key) => ({ ...result, [key]: input[key][Object.keys(input[key])[0]] }), {});
+const stripTypes = (input: Record<string, any>) =>
+  Object.keys(input).reduce((result, key) => ({ ...result, [key]: input[key][Object.keys(input[key])[0]] }), {});
 
 export const handler: DynamoDBStreamHandler = async ({ Records: records }) => {
   const aggregates = await loadAggregates() || {};

--- a/backend/src/handlers/http/aggregates/get.ts
+++ b/backend/src/handlers/http/aggregates/get.ts
@@ -1,0 +1,10 @@
+import { APIGatewayProxyHandlerWithData, checkEnvironment, wrapHttpHandler } from '../helpers';
+import { loadAggregates } from '../../../state/aggregates/persistence';
+
+export const getAggregatesHandler: APIGatewayProxyHandlerWithData = async ({}) => {
+  checkEnvironment(['BUCKET_AGGREGATES']);
+  const aggregates = await loadAggregates();
+  return { data: aggregates };
+};
+
+export const handler = wrapHttpHandler(getAggregatesHandler);

--- a/backend/src/handlers/http/aggregates/regenerate.ts
+++ b/backend/src/handlers/http/aggregates/regenerate.ts
@@ -1,0 +1,17 @@
+import { APIGatewayProxyHandlerWithData, checkEnvironment, wrapHttpHandler } from '../helpers';
+import { scanEvents } from '../../../events/scan';
+import { GameEventType } from '../../../events/types';
+import { buildAggregates } from '../../../state/aggregates';
+import { saveAggregates } from '../../../state/aggregates/persistence';
+
+export const regenerateAggregatesHandler: APIGatewayProxyHandlerWithData = async ({}) => {
+  checkEnvironment(['DB_TABLE_EVENTS', 'BUCKET_AGGREGATES']);
+  const events = await scanEvents(
+    'eventType',
+    [GameEventType.gameCreated, GameEventType.gameForfeited, GameEventType.victoryClaimed]);
+  const aggregates = await buildAggregates(events);
+  await saveAggregates(aggregates);
+  return { data: aggregates };
+};
+
+export const handler = wrapHttpHandler(regenerateAggregatesHandler);

--- a/backend/src/state/aggregates/index.ts
+++ b/backend/src/state/aggregates/index.ts
@@ -1,0 +1,46 @@
+import { Aggregates } from './types';
+import { GameCreatedEvent, GameEvent, GameEventType } from '../../events/types';
+import { buildStateFromEvents } from '../util';
+import { StateBuilder } from '../types';
+import { loadEvents } from '../../events/load';
+import { buildScoreState } from '../score';
+import { GameStatus } from '../../game/types';
+
+const createBlankAggregates = () => ({
+  [GameStatus.inProgress]: { games: 0 },
+  [GameStatus.forfeited]: { games: 0, score: 0, events: 0 },
+  [GameStatus.completed]: { games: 0, score: 0, events: 0 }
+})
+
+const recordGameResult = async (gameId: string, aggregates: Aggregates): Promise<Aggregates> => {
+  const gameEvents = await loadEvents(gameId);
+  const scoreState = buildScoreState(gameEvents);
+  const status = scoreState.status as GameStatus.completed | GameStatus.forfeited;
+  --aggregates[GameStatus.inProgress].games;
+  ++aggregates[status].games;
+  aggregates[status].score += scoreState.score;
+  aggregates[status].events += gameEvents.length;
+  return aggregates;
+}
+
+export const buildAggregates = (events: GameEvent[], initialAggregates?: Aggregates) =>
+  buildStateFromEvents<Promise<Aggregates>>(
+    Promise.resolve(initialAggregates || createBlankAggregates()),
+    { gameCreated, gameForfeited, victoryClaimed } as Record<GameEventType, StateBuilder<Promise<Aggregates>>>,
+    events);
+
+const gameCreated: StateBuilder<Promise<Aggregates>, GameCreatedEvent> = async (promise) => {
+  const aggregates = await promise;
+  ++aggregates[GameStatus.inProgress].games;
+  return aggregates;
+};
+
+const gameForfeited: StateBuilder<Promise<Aggregates>, GameCreatedEvent> = async (promise, { gameId }) => {
+  const aggregates = await promise;
+  return await recordGameResult(gameId, aggregates);
+};
+
+const victoryClaimed: StateBuilder<Promise<Aggregates>, GameCreatedEvent> = async (promise, { gameId }) => {
+  const aggregates = await promise;
+  return await recordGameResult(gameId, aggregates);
+};

--- a/backend/src/state/aggregates/index.ts
+++ b/backend/src/state/aggregates/index.ts
@@ -10,7 +10,7 @@ const createBlankAggregates = () => ({
   [GameStatus.inProgress]: { games: 0 },
   [GameStatus.forfeited]: { games: 0, score: 0, events: 0 },
   [GameStatus.completed]: { games: 0, score: 0, events: 0 }
-})
+});
 
 const recordGameResult = async (gameId: string, aggregates: Aggregates): Promise<Aggregates> => {
   const gameEvents = await loadEvents(gameId);
@@ -21,7 +21,7 @@ const recordGameResult = async (gameId: string, aggregates: Aggregates): Promise
   aggregates[status].score += scoreState.score;
   aggregates[status].events += gameEvents.length;
   return aggregates;
-}
+};
 
 export const buildAggregates = (events: GameEvent[], initialAggregates?: Aggregates) =>
   buildStateFromEvents<Promise<Aggregates>>(

--- a/backend/src/state/aggregates/persistence.ts
+++ b/backend/src/state/aggregates/persistence.ts
@@ -10,8 +10,7 @@ export const loadAggregates = async (): Promise<Aggregates> => {
       Key: GAME_AGGREGATES_OBJECT_KEY
     })
     .promise();
-  if (!body) throw 'Could not load aggregates';
-  return JSON.parse(body.toString());
+  return body ? JSON.parse(body.toString()) : undefined;
 };
 
 export const saveAggregates = async (aggregates: Aggregates): Promise<void> => {

--- a/backend/src/state/aggregates/persistence.ts
+++ b/backend/src/state/aggregates/persistence.ts
@@ -1,0 +1,25 @@
+import { S3 } from 'aws-sdk';
+import { Aggregates } from './types';
+
+const GAME_AGGREGATES_OBJECT_KEY = 'games.json';
+
+export const loadAggregates = async (): Promise<Aggregates> => {
+  const { Body: body } = await new S3()
+    .getObject({
+      Bucket: process.env.BUCKET_AGGREGATES as string,
+      Key: GAME_AGGREGATES_OBJECT_KEY
+    })
+    .promise();
+  if (!body) throw 'Could not load aggregates';
+  return JSON.parse(body.toString());
+};
+
+export const saveAggregates = async (aggregates: Aggregates): Promise<void> => {
+  await new S3()
+    .putObject({
+      Bucket: process.env.BUCKET_AGGREGATES as string,
+      Key: GAME_AGGREGATES_OBJECT_KEY,
+      Body: JSON.stringify(aggregates, null, 2)
+    })
+    .promise();
+};

--- a/backend/src/state/aggregates/types.ts
+++ b/backend/src/state/aggregates/types.ts
@@ -1,0 +1,13 @@
+import { GameStatus } from '../../game/types';
+
+export interface Aggregate {
+  games: number;
+  score: number;
+  events: number;
+}
+
+export interface Aggregates {
+  [GameStatus.inProgress]: Pick<Aggregate, 'games'>;
+  [GameStatus.forfeited]: Aggregate;
+  [GameStatus.completed]: Aggregate;
+}

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -73,7 +73,7 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref EventsTable
       Events:
-        GetGame:
+        PostGame:
           Type: Api
           Properties:
             Path: /game
@@ -92,7 +92,7 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref EventsTable
       Events:
-        GetGame:
+        PatchGame:
           Type: Api
           Properties:
             Path: /game/{gameId}/{moveType}
@@ -111,11 +111,77 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref EventsTable
       Events:
-        GetGame:
+        DeleteGame:
           Type: Api
           Properties:
             Path: /game/{gameId}
             Method: delete
+
+  GetAggregatesFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./build/handlers/http/aggregates
+      Handler: get.handler
+      ReservedConcurrentExecutions: 5
+      Timeout: 60
+      Environment:
+        Variables:
+          BUCKET_AGGREGATES: !Ref AggregatesBucket
+      Policies:
+        - S3ReadPolicy:
+            BucketName: !Ref AggregatesBucket
+      Events:
+        GetAggregates:
+          Type: Api
+          Properties:
+            Path: /aggregates
+            Method: get
+
+  RegenerateAggregatesFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./build/handlers/http/aggregates
+      Handler: regenerate.handler
+      ReservedConcurrentExecutions: 5
+      Timeout: 60
+      Environment:
+        Variables:
+          DB_TABLE_EVENTS: !Ref EventsTable
+          BUCKET_AGGREGATES: !Ref AggregatesBucket
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref EventsTable
+        - S3WritePolicy:
+            BucketName: !Ref AggregatesBucket
+      Events:
+        RegenerateAggregates:
+          Type: Api
+          Properties:
+            Path: /aggregates/regenerate
+            Method: get
+
+  StreamUpdateAggregatesFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./build/handlers/dynamodb/events
+      Handler: stream.handler
+      ReservedConcurrentExecutions: 5
+      Environment:
+        Variables:
+          DB_TABLE_EVENTS: !Ref EventsTable
+          BUCKET_AGGREGATES: !Ref AggregatesBucket
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref EventsTable
+        - S3CrudPolicy:
+            BucketName: !Ref AggregatesBucket
+      Events:
+        EventReceived:
+          Type: DynamoDB
+          Properties:
+            Stream: !GetAtt EventsTable.StreamArn
+            Enabled: True
+            StartingPosition: LATEST
 
   EventsTable:
     Type: AWS::DynamoDB::Table
@@ -132,6 +198,15 @@ Resources:
           AttributeType: S
         - AttributeName: eventTimestamp
           AttributeType: N
+      StreamSpecification:
+        StreamViewType: NEW_IMAGE
+
+  AggregatesBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "patience-aggregates-${Stage}"
+      VersioningConfiguration:
+        Status: Enabled
 
 Outputs:
   ApiBaseUrl:

--- a/backend/test/unit/events/scan.spec.ts
+++ b/backend/test/unit/events/scan.spec.ts
@@ -1,0 +1,258 @@
+import { SinonStub, stub } from 'sinon';
+import { expect } from 'chai';
+import mockedEnv from 'mocked-env';
+import { DynamoDB } from 'aws-sdk';
+import { GameEvent } from '../../../src/events/types';
+import { scanEvents } from '../../../src/events/scan';
+
+describe('Scanning events from the event store', () => {
+  describe('Given the environment is correctly configured', () => {
+    let restoreEnv: () => void;
+
+    beforeEach(() => {
+      restoreEnv = mockedEnv({
+        DB_TABLE_EVENTS: 'events_unit_test'
+      });
+    });
+
+    afterEach(() => {
+      restoreEnv();
+    });
+
+    describe('Given the event store is returning a single page of results', () => {
+      let scanStub: SinonStub;
+      let documentClientStub: SinonStub;
+
+      beforeEach(() => {
+        scanStub = stub().returns({
+          promise: stub().resolves({
+            Items: [
+              'first event',
+              'second event',
+              'third event'
+            ]
+          })
+        });
+
+        documentClientStub = stub(DynamoDB, 'DocumentClient').returns({ scan: scanStub });
+      });
+
+      afterEach(() => {
+        documentClientStub.restore();
+      });
+
+      describe('When invoked with a single filter value', () => {
+        let result: GameEvent[];
+
+        beforeEach(async () => {
+          result = await scanEvents('field', ['first value']);
+        });
+
+        it('Queries the database once', () => {
+          expect(scanStub.calledOnce).to.equal(true);
+          expect(scanStub.firstCall.args).to.deep.equal([
+            {
+              TableName: 'events_unit_test',
+              ExclusiveStartKey: undefined,
+              FilterExpression: '#key0 = :value0',
+              ExpressionAttributeNames: {
+                '#key0': 'field'
+              },
+              ExpressionAttributeValues: {
+                ':value0': 'first value'
+              }
+            }
+          ]);
+        });
+
+        it('Returns the correct results', () => {
+          expect(result).to.deep.equal(['first event', 'second event', 'third event']);
+        });
+      });
+
+      describe('When invoked with multiple filter values', () => {
+        let result: GameEvent[];
+
+        beforeEach(async () => {
+          result = await scanEvents('field', ['first value', 'second value', 'third value']);
+        });
+
+        it('Queries the database once', () => {
+          expect(scanStub.calledOnce).to.equal(true);
+          expect(scanStub.firstCall.args).to.deep.equal([
+            {
+              TableName: 'events_unit_test',
+              ExclusiveStartKey: undefined,
+              FilterExpression: '#key0 = :value0 or #key1 = :value1 or #key2 = :value2',
+              ExpressionAttributeNames: {
+                '#key0': 'field',
+                '#key1': 'field',
+                '#key2': 'field'
+              },
+              ExpressionAttributeValues: {
+                ':value0': 'first value',
+                ':value1': 'second value',
+                ':value2': 'third value'
+              }
+            }
+          ]);
+        });
+
+        it('Returns the correct results', () => {
+          expect(result).to.deep.equal(['first event', 'second event', 'third event']);
+        });
+      });
+    });
+
+    describe('Given the event store is returning multiple pages of results', () => {
+      let scanStub: SinonStub;
+      let documentClientStub: SinonStub;
+
+      beforeEach(() => {
+        scanStub = stub().returns({
+          promise: stub()
+            .onFirstCall().resolves({
+              Items: [
+                'first event',
+                'second event',
+                'third event'
+              ],
+              LastEvaluatedKey: 'there-are-more-results'
+            })
+            .onSecondCall().resolves({
+              Items: [
+                'fourth event',
+                'fifth event',
+                'sixth event'
+              ],
+              LastEvaluatedKey: 'still-more-results'
+            })
+            .onThirdCall().resolves({
+              Items: [
+                'final event'
+              ]
+            })
+        });
+
+        documentClientStub = stub(DynamoDB, 'DocumentClient').returns({ scan: scanStub });
+      });
+
+      afterEach(() => {
+        documentClientStub.restore();
+      });
+
+      describe('When invoked with multiple filter values', () => {
+        let result: GameEvent[];
+
+        beforeEach(async () => {
+          result = await scanEvents('field', ['first value', 'second value', 'third value']);
+        });
+
+        it('Queries the database once per page', () => {
+          expect(scanStub.calledThrice).to.equal(true);
+          expect(scanStub.firstCall.args).to.deep.equal([
+            {
+              TableName: 'events_unit_test',
+              ExclusiveStartKey: undefined,
+              FilterExpression: '#key0 = :value0 or #key1 = :value1 or #key2 = :value2',
+              ExpressionAttributeNames: {
+                '#key0': 'field',
+                '#key1': 'field',
+                '#key2': 'field'
+              },
+              ExpressionAttributeValues: {
+                ':value0': 'first value',
+                ':value1': 'second value',
+                ':value2': 'third value'
+              }
+            }
+          ]);
+          expect(scanStub.secondCall.args).to.deep.equal([
+            {
+              TableName: 'events_unit_test',
+              ExclusiveStartKey: 'there-are-more-results',
+              FilterExpression: '#key0 = :value0 or #key1 = :value1 or #key2 = :value2',
+              ExpressionAttributeNames: {
+                '#key0': 'field',
+                '#key1': 'field',
+                '#key2': 'field'
+              },
+              ExpressionAttributeValues: {
+                ':value0': 'first value',
+                ':value1': 'second value',
+                ':value2': 'third value'
+              }
+            }
+          ]);
+          expect(scanStub.thirdCall.args).to.deep.equal([
+            {
+              TableName: 'events_unit_test',
+              ExclusiveStartKey: 'still-more-results',
+              FilterExpression: '#key0 = :value0 or #key1 = :value1 or #key2 = :value2',
+              ExpressionAttributeNames: {
+                '#key0': 'field',
+                '#key1': 'field',
+                '#key2': 'field'
+              },
+              ExpressionAttributeValues: {
+                ':value0': 'first value',
+                ':value1': 'second value',
+                ':value2': 'third value'
+              }
+            }
+          ]);
+        });
+
+        it('Returns the correct results', () => {
+          expect(result).to.deep.equal([
+            'first event', 'second event', 'third event', 'fourth event', 'fifth event', 'sixth event', 'final event'
+          ]);
+        });
+      });
+    });
+
+    describe('Given the event store is causing errors', () => {
+      const thrownError = Error('Database failure code 666');
+      let scanStub: SinonStub;
+      let documentClientStub: SinonStub;
+
+      beforeEach(() => {
+        scanStub = stub().returns({
+          promise: stub().rejects(thrownError)
+        });
+
+        documentClientStub = stub(DynamoDB, 'DocumentClient').returns({ scan: scanStub });
+      });
+
+      afterEach(() => {
+        documentClientStub.restore();
+      });
+
+      describe('When invoked with multiple filter values', () => {
+        it('Throws the database error', async () => {
+          await expect(scanEvents('field', ['first value', 'second value', 'third value']))
+            .to.be.eventually.rejectedWith(thrownError);
+
+          expect(scanStub.calledOnce).to.equal(true);
+          expect(scanStub.firstCall.args).to.deep.equal([
+            {
+              TableName: 'events_unit_test',
+              ExclusiveStartKey: undefined,
+              FilterExpression: '#key0 = :value0 or #key1 = :value1 or #key2 = :value2',
+              ExpressionAttributeNames: {
+                '#key0': 'field',
+                '#key1': 'field',
+                '#key2': 'field'
+              },
+              ExpressionAttributeValues: {
+                ':value0': 'first value',
+                ':value1': 'second value',
+                ':value2': 'third value'
+              }
+            }
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/backend/test/unit/handlers/dynamodb/events/stream.spec.ts
+++ b/backend/test/unit/handlers/dynamodb/events/stream.spec.ts
@@ -56,7 +56,7 @@ describe('The DynamoDB events table stream handler', () => {
         it('Saves the aggregates', () => {
           expect(saveAggregatesStub.callCount).to.equal(1);
           expect(saveAggregatesStub.firstCall.args).to.deep.equal(['new aggregates']);
-        })
+        });
       });
     });
 

--- a/backend/test/unit/handlers/dynamodb/events/stream.spec.ts
+++ b/backend/test/unit/handlers/dynamodb/events/stream.spec.ts
@@ -1,0 +1,149 @@
+import { SinonStub, stub } from 'sinon';
+import { expect } from 'chai';
+import * as aggregatesModule from '../../../../../src/state/aggregates';
+import * as aggregatesPersistenceModule from '../../../../../src/state/aggregates/persistence';
+import { handler } from '../../../../../src/handlers/dynamodb/events/stream';
+import { Context } from 'aws-lambda';
+
+describe('The DynamoDB events table stream handler', () => {
+  const event = { Records: [{ dynamodb: { NewImage: { id: { S: 'first record' } } } }] };
+
+  describe('Given aggregates can be loaded and saved', () => {
+    let loadAggregatesStub: SinonStub;
+    let saveAggregatesStub: SinonStub;
+
+    beforeEach(() => {
+      loadAggregatesStub = stub(aggregatesPersistenceModule, 'loadAggregates').resolves('original aggregates' as any);
+      saveAggregatesStub = stub(aggregatesPersistenceModule, 'saveAggregates').resolves();
+    });
+
+    afterEach(() => {
+      loadAggregatesStub.restore();
+      saveAggregatesStub.restore();
+    });
+
+    describe('Given aggregates can be built', () => {
+      let buildAggregatesStub: SinonStub;
+
+      beforeEach(() => {
+        buildAggregatesStub = stub(aggregatesModule, 'buildAggregates').returns('new aggregates' as any);
+      });
+
+      afterEach(() => {
+        buildAggregatesStub.restore();
+      });
+
+      describe('When invoked', () => {
+        beforeEach(async () => {
+          await handler(
+            event,
+            {} as Context,
+            undefined as any);
+        });
+
+        it('Loads current aggregates', () => {
+          expect(loadAggregatesStub.callCount).to.equal(1);
+        });
+
+        it('Builds the new aggregates', () => {
+          expect(buildAggregatesStub.callCount).to.equal(1);
+          expect(buildAggregatesStub.firstCall.args).to.deep.equal([
+            [{ id: 'first record' }],
+            'original aggregates'
+          ]);
+        });
+
+        it('Saves the aggregates', () => {
+          expect(saveAggregatesStub.callCount).to.equal(1);
+          expect(saveAggregatesStub.firstCall.args).to.deep.equal(['new aggregates']);
+        })
+      });
+    });
+
+    describe('Given building aggregates generates an error', () => {
+      let buildAggregatesStub: SinonStub;
+      const buildAggregatesError = Error('Could not build aggregates');
+
+      beforeEach(() => {
+        buildAggregatesStub = stub(aggregatesModule, 'buildAggregates').throws(buildAggregatesError);
+      });
+
+      afterEach(() => {
+        buildAggregatesStub.restore();
+      });
+
+      describe('When invoked', () => {
+        it('Throws an error', async () => {
+          await expect(handler(event, {} as Context, undefined as any))
+            .to.be.eventually.rejectedWith(buildAggregatesError);
+
+          expect(loadAggregatesStub.callCount).to.equal(1);
+
+          expect(buildAggregatesStub.callCount).to.equal(1);
+          expect(buildAggregatesStub.firstCall.args).to.deep.equal([
+            [{ id: 'first record' }],
+            'original aggregates'
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('When loading aggregates generates an error', () => {
+    let loadAggregatesStub: SinonStub;
+    let saveAggregatesStub: SinonStub;
+    const loadError = Error('Could not load aggregates');
+
+    beforeEach(() => {
+      loadAggregatesStub = stub(aggregatesPersistenceModule, 'loadAggregates').rejects(loadError);
+      saveAggregatesStub = stub(aggregatesPersistenceModule, 'saveAggregates').resolves();
+    });
+
+    afterEach(() => {
+      loadAggregatesStub.restore();
+      saveAggregatesStub.restore();
+    });
+
+    it('Throws an error loading the aggregates', async () => {
+      await expect(handler(event, {} as Context, undefined as any))
+        .to.be.eventually.rejectedWith(loadError);
+
+      expect(loadAggregatesStub.callCount).to.equal(1);
+    });
+  });
+
+  describe('When loading aggregates is successful, but saving aggregates generates an error', () => {
+    let loadAggregatesStub: SinonStub;
+    let saveAggregatesStub: SinonStub;
+    let buildAggregatesStub: SinonStub;
+    const saveError = Error('Could not save aggregates');
+
+    beforeEach(() => {
+      loadAggregatesStub = stub(aggregatesPersistenceModule, 'loadAggregates').resolves('original aggregates' as any);
+      saveAggregatesStub = stub(aggregatesPersistenceModule, 'saveAggregates').rejects(saveError);
+      buildAggregatesStub = stub(aggregatesModule, 'buildAggregates').resolves('new aggregates' as any);
+    });
+
+    afterEach(() => {
+      loadAggregatesStub.restore();
+      saveAggregatesStub.restore();
+      buildAggregatesStub.restore();
+    });
+
+    it('Loads and builds the aggregates, then fails saving the aggregates', async () => {
+      await expect(handler(event, {} as Context, undefined as any))
+        .to.be.eventually.rejectedWith(saveError);
+
+      expect(loadAggregatesStub.callCount).to.equal(1);
+
+      expect(buildAggregatesStub.callCount).to.equal(1);
+      expect(buildAggregatesStub.firstCall.args).to.deep.equal([
+        [{ id: 'first record' }],
+        'original aggregates'
+      ]);
+
+      expect(saveAggregatesStub.callCount).to.equal(1);
+      expect(saveAggregatesStub.firstCall.args).to.deep.equal(['new aggregates']);
+    });
+  });
+});

--- a/backend/test/unit/handlers/http/aggregates/get.ts
+++ b/backend/test/unit/handlers/http/aggregates/get.ts
@@ -36,10 +36,10 @@ describe('The HTTP GET /aggregates handler', () => {
 
         beforeEach(async () => {
           result = await getAggregatesHandler({} as any, {} as Context, undefined as any);
-        })
+        });
 
         it('Returns the aggregates', () => {
-          expect(result).to.deep.equal({ data: 'aggregates data' })
+          expect(result).to.deep.equal({ data: 'aggregates data' });
         });
       });
     });

--- a/backend/test/unit/handlers/http/aggregates/get.ts
+++ b/backend/test/unit/handlers/http/aggregates/get.ts
@@ -1,0 +1,67 @@
+import { SinonStub, stub } from 'sinon';
+import mockedEnv from 'mocked-env';
+import { expect } from 'chai';
+import * as aggregatesPersistenceModule from '../../../../../src/state/aggregates/persistence';
+import { getAggregatesHandler } from '../../../../../src/handlers/http/aggregates/get';
+import { Context } from 'aws-lambda';
+import { APIGatewayProxyResultWithData } from '../../../../../src/handlers/http/helpers';
+
+describe('The HTTP GET /aggregates handler', () => {
+  describe('Given the environment is correctly configured', () => {
+    let restoreEnv: () => void;
+
+    beforeEach(() => {
+      restoreEnv = mockedEnv({
+        BUCKET_AGGREGATES: 'aggregates'
+      });
+    });
+
+    afterEach(() => {
+      restoreEnv();
+    });
+
+    describe('Given the aggregates can be loaded', () => {
+      let loadAggregatesStub: SinonStub;
+
+      beforeEach(() => {
+        loadAggregatesStub = stub(aggregatesPersistenceModule, 'loadAggregates').resolves('aggregates data' as any);
+      });
+
+      afterEach(() => {
+        loadAggregatesStub.restore();
+      });
+
+      describe('When invoked', () => {
+        let result: APIGatewayProxyResultWithData | void;
+
+        beforeEach(async () => {
+          result = await getAggregatesHandler({} as any, {} as Context, undefined as any);
+        })
+
+        it('Returns the aggregates', () => {
+          expect(result).to.deep.equal({ data: 'aggregates data' })
+        });
+      });
+    });
+
+    describe('Given loading aggregates causes an error', () => {
+      let loadAggregatesStub: SinonStub;
+      const loadError = Error('Could not load aggregates');
+
+      beforeEach(() => {
+        loadAggregatesStub = stub(aggregatesPersistenceModule, 'loadAggregates').rejects(loadError);
+      });
+
+      afterEach(() => {
+        loadAggregatesStub.restore();
+      });
+
+      describe('When invoked', () => {
+        it('Returns the aggregates', async () => {
+          await expect(getAggregatesHandler({} as any, {} as Context, undefined as any))
+            .to.be.eventually.rejectedWith(loadError);
+        });
+      });
+    });
+  });
+});

--- a/backend/test/unit/handlers/http/aggregates/regenerate.spec.ts
+++ b/backend/test/unit/handlers/http/aggregates/regenerate.spec.ts
@@ -1,0 +1,170 @@
+import mockedEnv from 'mocked-env';
+import { SinonStub, stub } from 'sinon';
+import * as scanEventsModule from '../../../../../src/events/scan';
+import * as aggregatesModule from '../../../../../src/state/aggregates';
+import * as aggregatesPersistenceModule from '../../../../../src/state/aggregates/persistence';
+import { createSampleCreateGameEvent } from '../../../../fixtures/events';
+import { regenerateAggregatesHandler } from '../../../../../src/handlers/http/aggregates/regenerate';
+import { expect } from 'chai';
+import { GameEventType } from '../../../../../src/events/types';
+
+describe('The HTTP GET /aggregates/regenerate handler', () => {
+  describe('Given the environment is correctly configured', () => {
+    let restoreEnv: () => void;
+
+    beforeEach(() => {
+      restoreEnv = mockedEnv({
+        DB_TABLE_EVENTS: 'events',
+        BUCKET_AGGREGATES: 'aggregates'
+      });
+    });
+
+    afterEach(() => {
+      restoreEnv();
+    });
+
+    describe('Given the game events can be scanned', () => {
+      let scanEventsStub: SinonStub;
+
+      beforeEach(() => {
+        scanEventsStub = stub(scanEventsModule, 'scanEvents').resolves([ createSampleCreateGameEvent() ]);
+      });
+
+      afterEach(() => {
+        scanEventsStub.restore();
+      });
+
+      describe('Given aggregates can be built', () => {
+        let buildAggregatesStub: SinonStub;
+
+        beforeEach(() => {
+          buildAggregatesStub = stub(aggregatesModule, 'buildAggregates').returns('aggregates' as any);
+        });
+
+        afterEach(() => {
+          buildAggregatesStub.restore();
+        });
+
+        describe('Given aggregates can be saved', () => {
+          let saveAggregatesStub: SinonStub;
+
+          beforeEach(() => {
+            saveAggregatesStub = stub(aggregatesPersistenceModule, 'saveAggregates').resolves();
+          });
+
+          afterEach(() => {
+            saveAggregatesStub.restore();
+          });
+
+          describe('When invoked', () => {
+            beforeEach(async () => {
+              await regenerateAggregatesHandler({} as any, {} as any, undefined as any);
+            });
+
+            it('Scans the event store', () => {
+              expect(scanEventsStub.callCount).to.equal(1);
+              expect(scanEventsStub.firstCall.args).to.deep.equal([
+                'eventType',
+                [GameEventType.gameCreated, GameEventType.gameForfeited, GameEventType.victoryClaimed]
+              ]);
+            });
+
+            it('Builds the aggregates', () => {
+              expect(buildAggregatesStub.callCount).to.equal(1);
+            });
+
+            it('Saves the aggregates data', () => {
+              expect(saveAggregatesStub.callCount).to.equal(1);
+              expect(saveAggregatesStub.firstCall.args).to.deep.equal(['aggregates']);
+            });
+          });
+        });
+
+        describe('Given saving aggregates fails', () => {
+          let saveAggregatesStub: SinonStub;
+          const saveError = Error('Could not save aggregates');
+
+          beforeEach(() => {
+            saveAggregatesStub = stub(aggregatesPersistenceModule, 'saveAggregates').rejects(saveError);
+          });
+
+          afterEach(() => {
+            saveAggregatesStub.restore();
+          });
+
+          describe('When invoked', () => {
+            it('Scans the event store, builds the aggregates then fails saving the aggregates', async () => {
+              await expect(regenerateAggregatesHandler({} as any, {} as any, undefined as any))
+                .to.eventually.be.rejectedWith(saveError);
+
+              expect(scanEventsStub.callCount).to.equal(1);
+              expect(scanEventsStub.firstCall.args).to.deep.equal([
+                'eventType',
+                [GameEventType.gameCreated, GameEventType.gameForfeited, GameEventType.victoryClaimed]
+              ]);
+
+              expect(buildAggregatesStub.callCount).to.equal(1);
+
+              expect(saveAggregatesStub.callCount).to.equal(1);
+              expect(saveAggregatesStub.firstCall.args).to.deep.equal(['aggregates']);
+            });
+          });
+        });
+      });
+
+      describe('Given building aggregates is failing', () => {
+        let buildAggregatesStub: SinonStub;
+        const buildError = Error('Could not build aggregates');
+
+        beforeEach(() => {
+          buildAggregatesStub = stub(aggregatesModule, 'buildAggregates').rejects(buildError);
+        });
+
+        afterEach(() => {
+          buildAggregatesStub.restore();
+        });
+
+        describe('When invoked', () => {
+          it('Scans the event store, then throws an error building the aggregates', async () => {
+            await expect(regenerateAggregatesHandler({} as any, {} as any, undefined as any))
+              .to.be.eventually.rejectedWith(buildError);
+
+            expect(scanEventsStub.callCount).to.equal(1);
+            expect(scanEventsStub.firstCall.args).to.deep.equal([
+              'eventType',
+              [GameEventType.gameCreated, GameEventType.gameForfeited, GameEventType.victoryClaimed]
+            ]);
+
+            expect(buildAggregatesStub.callCount).to.equal(1);
+          });
+        });
+      });
+    });
+
+    describe('Given scanning the game events fails', () => {
+      let scanEventsStub: SinonStub;
+      const scanError = Error('Cannot load game events');
+
+      beforeEach(() => {
+        scanEventsStub = stub(scanEventsModule, 'scanEvents').rejects(scanError);
+      });
+
+      afterEach(() => {
+        scanEventsStub.restore();
+      });
+
+      describe('When invoked', () => {
+        it('Throws an error scanning the event store', async () => {
+          await expect(regenerateAggregatesHandler({} as any, {} as any, undefined as any))
+            .to.be.eventually.rejectedWith(scanError);
+
+          expect(scanEventsStub.callCount).to.equal(1);
+          expect(scanEventsStub.firstCall.args).to.deep.equal([
+            'eventType',
+            [GameEventType.gameCreated, GameEventType.gameForfeited, GameEventType.victoryClaimed]
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/backend/test/unit/state/aggregates/index.spec.ts
+++ b/backend/test/unit/state/aggregates/index.spec.ts
@@ -1,0 +1,216 @@
+import { SinonStub, stub } from 'sinon';
+import { expect } from 'chai';
+import * as loadEventsModule from '../../../../src/events/load';
+import { Aggregates } from '../../../../src/state/aggregates/types';
+import { buildAggregates } from '../../../../src/state/aggregates';
+import { GameEventType } from '../../../../src/events/types';
+
+describe('The aggregates builder', () => {
+  describe('When events for a game can be loaded', () => {
+    let loadEventsStub: SinonStub;
+
+    beforeEach(() => {
+      loadEventsStub = stub(loadEventsModule, 'loadEvents');
+    });
+
+    afterEach(() => {
+      loadEventsStub.restore();
+    });
+
+    describe('When provided an empty list of events', () => {
+      let aggregates: Aggregates;
+
+      beforeEach(async () => {
+        aggregates = await buildAggregates([]);
+      });
+
+      it('Returns a zero aggregate', () => {
+        expect(aggregates).to.deep.equal({
+          inProgress: {
+            games: 0
+          },
+          forfeited: {
+            games: 0,
+            score: 0,
+            events: 0
+          },
+          completed: {
+            games: 0,
+            score: 0,
+            events: 0
+          }
+        });
+      });
+    });
+
+    describe('When provided an empty list of events and initial aggregates', () => {
+      let aggregates: Aggregates;
+
+      beforeEach(async () => {
+        aggregates = await buildAggregates([], {
+          inProgress: {
+            games: 12
+          },
+          forfeited: {
+            games: 42,
+            score: 1234,
+            events: 234
+          },
+          completed: {
+            games: 1,
+            score: 500,
+            events: 100
+          }
+        });
+      });
+
+      it('Returns the initial aggregates unmodified', () => {
+        expect(aggregates).to.deep.equal({
+          inProgress: {
+            games: 12
+          },
+          forfeited: {
+            games: 42,
+            score: 1234,
+            events: 234
+          },
+          completed: {
+            games: 1,
+            score: 500,
+            events: 100
+          }
+        });
+      });
+    });
+
+    describe('When provided a list containing a single game creation event', () => {
+      let aggregates: Aggregates;
+
+      beforeEach(async () => {
+        aggregates = await buildAggregates([
+          {
+            eventType: GameEventType.gameCreated,
+            gameId: 'test1',
+            eventTimestamp: Date.now()
+          }
+        ]);
+      });
+
+      it('Returns an aggregate describing a single in-progress game', () => {
+        expect(aggregates).to.deep.equal({
+          inProgress: {
+            games: 1
+          },
+          forfeited: {
+            games: 0,
+            score: 0,
+            events: 0
+          },
+          completed: {
+            games: 0,
+            score: 0,
+            events: 0
+          }
+        });
+      });
+    });
+
+    describe('When provided a list containing a single game creation event, with initial aggregates', () => {
+      let aggregates: Aggregates;
+
+      beforeEach(async () => {
+        aggregates = await buildAggregates(
+          [
+            {
+              eventType: GameEventType.gameCreated,
+              gameId: 'test1',
+              eventTimestamp: Date.now()
+            }
+          ],
+          {
+            inProgress: {
+              games: 12
+            },
+            forfeited: {
+              games: 42,
+              score: 1234,
+              events: 234
+            },
+            completed: {
+              games: 1,
+              score: 500,
+              events: 100
+            }
+          });
+      });
+
+      it('Returns the initial aggregates plus one additional in-progress game', () => {
+        expect(aggregates).to.deep.equal({
+          inProgress: {
+            games: 13
+          },
+          forfeited: {
+            games: 42,
+            score: 1234,
+            events: 234
+          },
+          completed: {
+            games: 1,
+            score: 500,
+            events: 100
+          }
+        });
+      });
+    });
+
+    describe('When provided a list containing a single game forfeit event, with initial aggregates', () => {
+      let aggregates: Aggregates;
+
+      beforeEach(async () => {
+        const forfeitedEvent = {
+          eventType: GameEventType.gameForfeited,
+          gameId: 'test1',
+          eventTimestamp: Date.now()
+        };
+
+        loadEventsStub.resolves([forfeitedEvent]);
+
+        aggregates = await buildAggregates(
+          [forfeitedEvent],
+          {
+            inProgress: {
+              games: 12
+            },
+            forfeited: {
+              games: 42,
+              score: 1234,
+              events: 235
+            },
+            completed: {
+              games: 1,
+              score: 500,
+              events: 100
+            }
+          });
+      });
+
+      it('Returns the initial aggregates plus one game moved from in-progress to forfeited', () => {
+        expect(aggregates).to.deep.equal({
+          inProgress: {
+            games: 11
+          },
+          forfeited: {
+            games: 43,
+            score: 1234,
+            events: 236
+          },
+          completed: {
+            games: 1,
+            score: 500,
+            events: 100
+          }
+        });
+      });
+    });
+  });
+});

--- a/backend/test/unit/state/score/index.spec.ts
+++ b/backend/test/unit/state/score/index.spec.ts
@@ -5,11 +5,11 @@ import {
   StockDealtToWasteEvent,
   TableauPlayedToFoundationEvent,
   TableauPlayedToTableauEvent
-} from '../../../src/events/types';
-import { createSampleCreateGameEvent } from '../../fixtures/events';
-import { ScoreState } from '../../../src/state/score/types';
-import { buildScoreState } from '../../../src/state/score';
-import { GameStatus } from '../../../src/game/types';
+} from '../../../../src/events/types';
+import { createSampleCreateGameEvent } from '../../../fixtures/events';
+import { ScoreState } from '../../../../src/state/score/types';
+import { buildScoreState } from '../../../../src/state/score';
+import { GameStatus } from '../../../../src/game/types';
 
 describe('The score state builder', () => {
   describe('When provided an empty list of events', () => {

--- a/backend/test/unit/state/table/index.spec.ts
+++ b/backend/test/unit/state/table/index.spec.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
-import { buildTableState } from '../../../src/state/table';
-import { Suit, Value } from '../../../src/game/types';
+import { buildTableState } from '../../../../src/state/table';
+import { Suit, Value } from '../../../../src/game/types';
 import {
   GameEventType,
   StockDealtToWasteEvent,
   TableauPlayedToFoundationEvent,
   TableauPlayedToTableauEvent
-} from '../../../src/events/types';
-import { createSampleCreateGameEvent } from '../../fixtures/events';
-import { TableState } from '../../../src/state/table/types';
+} from '../../../../src/events/types';
+import { createSampleCreateGameEvent } from '../../../fixtures/events';
+import { TableState } from '../../../../src/state/table/types';
 
 describe('The table state builder', () => {
   describe('When provided an empty list of events', () => {


### PR DESCRIPTION
+ Store aggregate game and score data as a JSON file in S3
+ Add S3 bucket resource
+ Add an endpoint to retrieve the aggregates
+ Add an endpoint to regenerate the aggregates from raw events data
+ Add a stream handler ot update the aggregates on the fly
+ Some additional test cleanup
+ Moved a couple of files for consistent directory structure